### PR TITLE
ROCANA-7226: Rewrite gogen-avro import

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/alanctgardner/gogen-avro/generator"
+	"github.com/scalingdata/gogen-avro/generator"
 	"io/ioutil"
 	"os"
 )


### PR DESCRIPTION
Imports our fork rather than upstream.
